### PR TITLE
Add Dockerfile and docker-compose.yml for Fully Dockerized Seed-E Deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+EXPOSE 3000
+CMD ["npm", "run", "start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,18 @@
 version: "3.8"
 services:
+  app:
+    build: .
+    ports:
+      - "3000:3000"
+    environment:
+      - NODE_ENV=production
+      - DATABASE_URL=postgresql://seed-e-user:${POSTGRES_PASSWORD}@postgres:5432/seed-e-db
+      - XPUB_HASH_SECRET=${XPUB_HASH_SECRET}
+      - NEXTAUTH_SECRET=${NEXTAUTH_SECRET}
+      - NEXTAUTH_URL=http://localhost:3000
+depends_on:
+      - postgres
+    restart: always
   postgres:
     image: postgres:14-alpine
     restart: always
@@ -11,6 +24,5 @@ services:
       - "5433:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
-
 volumes:
   postgres_data:


### PR DESCRIPTION
This PR adds a Dockerfile and docker-compose.yml to enable a fully Dockerized deployment of Seed-E, including the Node.js application and PostgreSQL database. The setup uses environment variables for sensitive data (e.g., POSTGRES_PASSWORD, XPUB_HASH_SECRET, NEXTAUTH_SECRET) to ensure security. Tested on an Ubuntu 24.04 VM with Caddy reverse proxy to a FQDN with TLS. The existing bare metal installation instructions remain supported, providing deployment flexibility. This facilitates CI/CD pipelines (e.g., GitHub Actions) for automated updates.